### PR TITLE
only run flake8 on our own code, not on our dependencies'

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,7 @@ envlist =
 [testenv]
 commands =
     pip install -e tests
-    make test
-    flake8
+    make test lint
     py34-django19: make docs
 setenv =
     DJANGO_SETTINGS_MODULE = settings


### PR DESCRIPTION
this came out once CI ran tox with `-r` and flake8 was upgraded too
