### PR TITLE
fix readme errors preventing the release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ output/*/index.html
 
 # Sphinx
 docs/_build
+no-readme-errors

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TRAVIS_YML=.travis.yml
 TOX2TRAVIS=tox2travis.py
-.PHONY: clean-pyc clean-build docs clean-tox ${TRAVIS_YML} ci
+.PHONY: clean-pyc clean-build docs clean-tox ${TRAVIS_YML} ci no-readme-errors
 PYPI_SERVER?=https://pypi.python.org/pypi
 SHELL=/bin/bash
 
@@ -26,6 +26,11 @@ ${TRAVIS_YML}: tox.ini ${TOX2TRAVIS}
 
 clean: clean-build clean-pyc clean-tox
 	cd docs && make clean
+
+no-readme-errors:
+	rst2html.py README.rst > /dev/null 2> $@
+	cat $@
+	test 0 -eq `cat $@ | wc -l`
 
 docs:
 	cd docs && make html

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Pull Requests
 Setting up all Python versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code:: bash
+::
 
     sudo apt-get -y install software-properties-common
     sudo add-apt-repository ppa:fkrull/deadsnakes

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ commands =
     pip install -e tests
     make test lint
     py34-django19: make docs
+    py34-django18: make no-readme-errors
 setenv =
     DJANGO_SETTINGS_MODULE = settings
 deps =
@@ -25,6 +26,7 @@ deps =
     django111: Django>=1.11,<1.12
     flake8
     py34-django19: sphinx
+    py34-django18: docutils
 whitelist_externals = make
 
 [flake8]


### PR DESCRIPTION
followup to #7 

I have remove the prematurely create release tag by running

    $ tag=v0.1.7
    $ git tag -d $tag
    $ git push origin :refs/tags/$tag

used a different tox env 'coz docutils installs pygments - the absence of which is causing the release failure