### PR TITLE
Lint: no bare 'except'

### DIFF
--- a/tests/testapp/sixmock.py
+++ b/tests/testapp/sixmock.py
@@ -1,4 +1,4 @@
 try:
     from unittest.mock import call, patch, Mock, PropertyMock, MagicMock  # noqa: E501
-except:
+except ImportError:
     from mock import call, patch, Mock, PropertyMock, MagicMock  # noqa: F401


### PR DESCRIPTION
The latest lint package fails the build with that.